### PR TITLE
Enable CSS customization of link hints

### DIFF
--- a/sVim.safariextension/sVim.css
+++ b/sVim.safariextension/sVim.css
@@ -1,2 +1,9 @@
-#test {
+.sVimLinkHint {
+    color: #000;
+    font-size: 10pt;
+    font-family: monospace;
+    line-height: 10pt;
+    padding: 0px;
+    margin: 0px;
+    opacity: 0.7;
 }

--- a/sVim.safariextension/sVimGlobal.html
+++ b/sVim.safariextension/sVimGlobal.html
@@ -73,6 +73,7 @@
 
           // Send updated settings to each tab
           sVimGlobal.sendUpdatedSettings();
+          sVimGlobal.sendUpdatedrc();
         },
 
         // Open help page in new tab
@@ -537,6 +538,17 @@
           var tabs = browserWindows[j].tabs;
           for (var i = 0; i < tabs.length; i++) {
             sVimGlobal.commands["sendSettings"](tabs[i]);
+          }
+        }
+      };
+
+      // Send rc updates to all tabs
+      sVimGlobal.sendUpdatedrc = function() {
+        var browserWindows = safari.application.browserWindows;
+        for (var j = 0; j < browserWindows.length; j++) {
+          var tabs = browserWindows[j].tabs;
+          for (var i = 0; i < tabs.length; i++) {
+            sVimGlobal.commands["sendsVimrc"](tabs[i]);
           }
         }
       };

--- a/sVim.safariextension/sVimHint.js
+++ b/sVim.safariextension/sVimHint.js
@@ -15,6 +15,8 @@ sVimHint.start = function(newTab) {
   var inputKey = "";
   var lastMatchHint = null;
   var k=0;
+  var hintClass = "sVimLinkHint";
+  var hintStyleId = "sVimLinkHintStyle";
 
   function getAbsolutePosition( elem, html, body, inWidth, inHeight ){
     var style = getComputedStyle(elem,null);
@@ -58,10 +60,17 @@ sVimHint.start = function(newTab) {
 
   function injectCSS(doc, css)
   {
-    var style = doc.createElement('style');
-    style.type = 'text/css';
-    style.innerHTML = css;
-    doc.getElementsByTagName('head')[0].appendChild(style);
+    var style = doc.getElementById(hintStyleId);
+    if (style) {
+      style.innerHTML = css;
+    }
+    else {
+      style = doc.createElement('style');
+      style.type = 'text/css';
+      style.id = hintStyleId;
+      style.innerHTML = css;
+      doc.getElementsByTagName('head')[0].appendChild(style);
+    }
   }
 
   function start(win){
@@ -88,7 +97,7 @@ sVimHint.start = function(newTab) {
       var hint = createText(k);
       var span = win.document.createElement("span");
       span.appendChild(document.createTextNode(hint));
-      span.className = "sVimLinkHint";
+      span.className = hintClass;
       var st = span.style;
       for( key in spanStyle ){
         st[key] = spanStyle[key];

--- a/sVim.safariextension/sVimHint.js
+++ b/sVim.safariextension/sVimHint.js
@@ -56,6 +56,14 @@ sVimHint.start = function(newTab) {
     return arr;
   }
 
+  function injectCSS(doc, css)
+  {
+    var style = doc.createElement('style');
+    style.type = 'text/css';
+    style.innerHTML = css;
+    doc.getElementsByTagName('head')[0].appendChild(style);
+  }
+
   function start(win){
     var html = win.document.documentElement;
     var body = win.document.body;
@@ -69,14 +77,10 @@ sVimHint.start = function(newTab) {
     var spanStyle = {
       "position" : "absolute",
       "zIndex" : "214783647",
-      "color" : "#000",
-      "fontSize" : "10pxt",
-      "fontFamily" : "monospace",
-      "lineHeight" : "10pt",
-      "padding" : "0px",
-      "margin" : "0px",
-      "opacity" : "0.7"
     };
+
+    injectCSS(win.document, sVimTab.sVimrc.css);
+
     var elems = getXPathElements(win);
     elems.forEach(function(elem){
       var pos = getAbsolutePosition(elem, html, body, inWidth, inHeight );
@@ -84,6 +88,7 @@ sVimHint.start = function(newTab) {
       var hint = createText(k);
       var span = win.document.createElement("span");
       span.appendChild(document.createTextNode(hint));
+      span.className = "sVimLinkHint";
       var st = span.style;
       for( key in spanStyle ){
         st[key] = spanStyle[key];

--- a/sVim.safariextension/sVimTab.js
+++ b/sVim.safariextension/sVimTab.js
@@ -3,6 +3,8 @@ var sVimTab = {};
 //setTimeout(function(){
 // Settings passed in from global
 sVimTab.settings = {};
+// rc passed in from global
+sVimTab.sVimrc = {};
 // Indicates the tab mode
 sVimTab.mode = "normal";
 // Indicates if window is top
@@ -444,11 +446,15 @@ sVimTab.scrollBy = function(x, y) {
 
 // Init sVimTab
 safari.self.tab.dispatchMessage("sendSettings");
+safari.self.tab.dispatchMessage("sendsVimrc");
 
 // Catch commands from global
 safari.self.addEventListener("message", function(event) {
   if (event.name == "settings") {
     sVimTab.settings = event.message;
     sVimTab.bind();
+  }
+  else if (event.name == "sVimrc") {
+    sVimTab.sVimrc = event.message;
   }
 }, false);


### PR DESCRIPTION
Fixes Issue #8 - Custom CSS for link follow hints

This approach to getting the CSS content from the RC into the sVimTabs (essentially duplicating the "settings" messages with the RC itself) may not be what was envisioned.  Perhaps it would be better to pass a message with just the CSS content rather than the whole RC.  Or, perhaps it would be better to make the CSS a member of the settings object.  Let me know if you have a preference.  Thanks!