### PR TITLE
sVimGlobal: Automatically focus on new tab.

### DIFF
--- a/sVim.safariextension/sVimGlobal.html
+++ b/sVim.safariextension/sVimGlobal.html
@@ -624,6 +624,13 @@
         }
       }, true);
 
+      // Catch navigate event to focus on the new page.
+      safari.application.addEventListener("navigate", function(event) {
+        // Switching back and forth rapidly deselects search bar and is invisible.
+        sVimGlobal.commands.previousTab();
+        sVimGlobal.commands.nextTab();
+      }, true);
+
       // Catch close command from tab
       safari.application.addEventListener("close", function(event) {
         // Keep track of closed tabs


### PR DESCRIPTION
Scenario: Create new tab, write search or url in searchbar, press tab
4 times.

This tricks safari to focus on the new tab once the user
navigates to a url, removing the need to use tab to focus
the page.

[edit] Sorry for double PR, working on another feature now.
