### PR TITLE
Changed openReader to toggleReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The functionality of sVim will mostly follow the Chrome extension [cVim](https:/
 | "z i"                  | zoom page in                                   | zoomPageIn              |
 | "z o"                  | zoom page out                                  | zoomPageOut             |
 | "z 0"                  | zoom page to original size                     | zoomOrig                |
-| "g r"                  | open Safari reader if possible                 | openReader              |
+| "g r"                  | toggle Safari reader if possible               | toggleReader            |
 | "g v"                  | show sVimrc page                               | showsVimrc              |
 | "g ?"                  | open help page in new tab                      | help                    |
 | **Tab Navigation**     |                                                |                         |

--- a/sVim.safariextension/sVimGlobal.html
+++ b/sVim.safariextension/sVimGlobal.html
@@ -18,8 +18,12 @@
       // Define commands that can be run
       sVimGlobal.commands = {
         // Open Safari reader if possible
-        openReader: function() {
-          safari.application.activeBrowserWindow.activeTab.reader.enter();
+        toggleReader: function() {
+          if (safari.application.activeBrowserWindow.activeTab.reader.visible) {
+            safari.application.activeBrowserWindow.activeTab.reader.exit();
+          } else {
+            safari.application.activeBrowserWindow.activeTab.reader.enter();
+          }
         },
 
         // Close Safari reader if possible
@@ -365,7 +369,7 @@
           "z i"           : "zoomPageIn",
           "z o"           : "zoomPageOut",
           "z 0"           : "zoomOrig",
-          "g r"           : "openReader",
+          "g r"           : "toggleReader",
           "g v"           : "showsVimrc",
           "g ?"           : "help",
           // Tab Navigation

--- a/sVim.safariextension/sVimTab.js
+++ b/sVim.safariextension/sVimTab.js
@@ -114,8 +114,8 @@ sVimTab.commands = {
   },
 
   // Open Safari reader if possible
-  openReader: function() {
-    safari.self.tab.dispatchMessage("openReader");
+  toggleReader: function() {
+    safari.self.tab.dispatchMessage("toggleReader");
   },
 
   // Close Safari reader if possible


### PR DESCRIPTION
I feel it makes more sense if the same shortcut would be used to both open the reader and close the reader (if the reader view is already opened)
