### PR TITLE
Removed function `blurHint()` which is not working. Expanded types of elements for hint.

### DIFF
--- a/sVim.safariextension/sVimHint.js
+++ b/sVim.safariextension/sVimHint.js
@@ -4,7 +4,7 @@ var sVimHint = {};
 // Start hint
 sVimHint.start = function(newTab) {
   var hintKeys = new String(sVimTab.settings.hintcharacters).toUpperCase();
-  var xpath = "//a[@href]|//input[not(@type=\x22hidden\x22)]|//textarea|//select|//img[@onclick]|//button";
+  var xpath = "//a|//input[not(@type=\x22hidden\x22)]|//textarea|//select|//img[@onclick]|//button|//div[@role=\x22button\x22]";
   var keyMap = {"8": "Bkspc", "46": "Delete", "32": "Space", "13":"Enter", "16": "Shift", "17": "Ctrl", "18": "Alt"};
 
   var hintKeysLength;
@@ -204,7 +204,6 @@ sVimHint.start = function(newTab) {
       default:
         inputKey += onkey;
     }
-    blurHint();
     if (inputKey in hintElements === false) {
       resetInput();
       inputKey += onkey;
@@ -251,17 +250,8 @@ sVimHint.start = function(newTab) {
     }, this);
   }
 
-  function blurHint(){
-    if(lastMatchHint){
-      if (lastMatchHint.element.hasAttribute("href") !== true) {
-        span.classList.add("sVim-hint-form");
-      }
-    }
-  }
-
   function resetInput(){
     inputKey = "";
-    blurHint();
     lastMatchHint = null;
   }
 


### PR DESCRIPTION
1. The function `blurHint()` is not working. The variable `span` is an undefined variable within the function and thus whenever I want to focus on a form a JS error is triggered.
2. Expanded types of elements matched so that the upvote/downvote buttons on SE/Reddit can also be pressed directly from hints. See https://github.com/flipxfx/sVim/issues/22
