### PR TITLE
Implements goto prev/next page feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The functionality of sVim will mostly follow the Chrome extension [cVim](https:/
 | "0"                    | scroll to the left of the page                 | scrollToLeft            |
 | "$"                    | scroll to the right of the page                | scrollToRight           |
 | "g i"                  | go to the first input box                      | goToInput               |
+| "g n"                  | find a "next page" link and navigate to it     | gotoNextPage            |
+| "g p"                  | find a "previous page" link and navigate to it | gotoPrevPage            |
 | **Miscellaneous**      |                                                |                         |
 | "r"                    | reload the current tab                         | reloadTab               |
 | "z i"                  | zoom page in                                   | zoomPageIn              |
@@ -125,6 +127,8 @@ The functionality of sVim will mostly follow the Chrome extension [cVim](https:/
 | mapleader             | <Leader> key                                                                                | string  | "\"               |
 | newtaburl             | url to use as the default new tab url                                                       | string  | "topsites://"     |
 | blacklists            | disable sVim on the sites matching one of the patterns                                      | array   | []                |
+| nextpagetextpatterns  | a list of regex patterns used to find the "next page" link on the page                      | array   | ["Next"]          |
+| prevpagetextpatterns  | a list of regex patterns used to find the "prev page" link on the page                      | array   | ["Previous"]      |
 
 ### sVimrc Example
 ```viml
@@ -141,6 +145,8 @@ let homeurl = "http://google.com";
 let mapleader = ","
 let newtaburl = "http://google.com"
 let blacklists = ["*://example.com/stuff/*", "*://mail.google.com/*"]
+let nextpagetextpatterns = ["Next"]
+let prevpagetextpatterns = ["Prev(ious)?"]
 
 " Shortcuts
 map "q" nextTab

--- a/sVim.safariextension/sVimGlobal.html
+++ b/sVim.safariextension/sVimGlobal.html
@@ -360,6 +360,8 @@
         sVimGlobal.settings.mapleader             = "\\";
         sVimGlobal.settings.newtaburl             = "topsites://";
         sVimGlobal.settings.blacklists            = [];
+        sVimGlobal.settings.nextpagetextpatterns  = ["Next"];
+        sVimGlobal.settings.prevpagetextpatterns  = ["Prev(ious)?"];
 
         // Load default shortcuts (private setting)
         sVimGlobal.settings.shortcuts = {
@@ -378,6 +380,8 @@
           "0"             : "scrollToLeft",
           "$"             : "scrollToRight",
           "g i"           : "goToInput",
+          "g n"           : "gotoNextPage",
+          "g p"           : "gotoPrevPage",
           // Miscellaneous
           "r"             : "reloadTab",
           "z i"           : "zoomPageIn",

--- a/sVim.safariextension/sVimTab.js
+++ b/sVim.safariextension/sVimTab.js
@@ -320,7 +320,36 @@ sVimTab.commands = {
   yankDocumentUrl: function() {
     var text = window.location.href;
     sVimHelper.copyToClipboard(text);
-  }
+  },
+
+  // Find a link with that matches one of the given text patterns (regex-s),
+  // and click on it.
+  clickLinkMatchingTextPatterns: function(patterns) {
+    var links = document.getElementsByTagName("a");
+
+    for (i=0; i<links.length; i++) {
+      var link = links[i];
+
+      for (j=0; j<patterns.length; j++) {
+        var re = new RegExp('^' + patterns[j] + '$');
+
+        if (re.test(link.text)) {
+          link.click();
+          return;
+        }
+      }
+    }
+  },
+
+  // Click on the "next page" link on the screen if any is present
+  gotoNextPage: function() {
+    this.clickLinkMatchingTextPatterns(sVimTab.settings.nextpagetextpatterns);
+  },
+
+  // Click on the "previous page" link on the screen if any is present
+  gotoPrevPage: function() {
+    this.clickLinkMatchingTextPatterns(sVimTab.settings.prevpagetextpatterns);
+  },
 };
 
 // Bind shortcuts


### PR DESCRIPTION
For now I implemented a very naive algorithm that looks for <a> with
matching text. It would probably be better to somehow reuse the logic in
the hint link discovery, but it is actually subtly different here.  In
hint link discovery, we do a DFS from the root document, and stop
recursing whenever we identify a link. But here we actually want to
visit every child, since the text could potentially be on one of the
child elements instead.

Text matching patterns for next/previous page links can be configured as
`nextpagetextpatterns` and `prevpagetextpatterns` options in sVimrc.

Default settings tested on Google, and GitHub issue page.