### PR TITLE
Make hint container static. Fixes #98

### DIFF
--- a/sVim.safariextension/sVimHint.js
+++ b/sVim.safariextension/sVimHint.js
@@ -190,6 +190,7 @@ sVimHint.start = function(newTab) {
     var df = document.createDocumentFragment();
     var div = df.appendChild(document.createElement("div"));
     div.id = hintContainerId;
+    div.style.position = "static";
 
     var spanStyle = {
       "position" : "absolute",


### PR DESCRIPTION
Instagram sets divs to `position: relative` which interferes with the positioning of our hints within the hint container. Making the container explicitly static fixes this.