### PR TITLE
Docs: Note that example sVimrc is for >= v1.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ The functionality of sVim will mostly follow the Chrome extension [cVim](https:/
 | prevpagetextpatterns  | a list of regex patterns used to find the "prev page" link on the page                      | array   | ["Previous"]      |
 
 ### sVimrc Example
+
+Note: This example config works with sVim v1.0.7 and newer.
+If running an older version, remove or comment out the `nextpagetextpatterns` and `prevpagetextpatterns` lines.
+
 ```viml
 " Settings
 set nosmoothscroll


### PR DESCRIPTION
Per Issue #107 

Just a warning for people still on sVim 1.0.6 (everyone who's upgraded to Safari 12, I think?) that the example sVimrc won't work without modification.

Once Apple gets their act together and adds 1.0.7 to Extensions Gallery/App Store, this can probably be reverted/removed.